### PR TITLE
Fix broken mult macro

### DIFF
--- a/ops.inc
+++ b/ops.inc
@@ -51,11 +51,9 @@ mult: macro
     ld HL, 0
     ld B, \1
     ld C, \2
-    xor A
 
     ; If either of the operands are 0, return 0
-    or B
-        jr Z, .end\@
+    ld A, B
     or C
         jr Z, .end\@
 


### PR DESCRIPTION
If the first check passes, then the second one will always fail. Also grouping both checks saves 3 bytes.