### PR TITLE
Improve dbs macro

### DIFF
--- a/ops.inc
+++ b/ops.inc
@@ -23,13 +23,16 @@ endm
 
 ;;;
 ; Inserts a null terminated string into ROM
-; dbs string
+; dbs bits,of,string
 ; Bytes: Length of String + 1
 ; Cycles: N/A
 ; Flags: N/A
 ;;;
 dbs: macro
-    db \1,0
+    REPT _NARG
+        db \1
+    ENDR
+    db 0
 endm
 
 ;;;

--- a/ops.inc
+++ b/ops.inc
@@ -23,7 +23,7 @@ endm
 
 ;;;
 ; Inserts a null terminated string into ROM
-; dbs bits,of,string
+; dbs string, ...
 ; Bytes: Length of String + 1
 ; Cycles: N/A
 ; Flags: N/A
@@ -31,6 +31,7 @@ endm
 dbs: macro
     REPT _NARG
         db \1
+        SHIFT
     ENDR
     db 0
 endm


### PR DESCRIPTION
Allow syntax closer to `db` for strings such as `dbs "Balance: ", PRINT_DECIMAL, wPlayerBalance, " coins."`